### PR TITLE
Adds mypy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Python
 venv
+.mypy_cache
 *.egg-info
 *.pyc
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: pip-compile pip-install type
+
+pip-compile:
+	source venv/bin/activate; pip-compile requirements.in
+
+pip-install:
+	source venv/bin/activate; pip install -r requirements.txt
+
+type:
+	source venv/bin/activate; mypy --ignore-missing-imports .;
+
+build: pip-install type

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,3 @@
 pip-tools==2.0.2
+mypy==0.630
+mypy_extensions==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,8 @@
 #
 click==7.0                # via pip-tools
 first==2.0.1              # via pip-tools
+mypy-extensions==0.4.1
+mypy==0.630
 pip-tools==2.0.2
 six==1.11.0               # via pip-tools
+typed-ast==1.1.0          # via mypy


### PR DESCRIPTION
Adds mypy support. You can run the mypy type checker by running
`make test`. This also adds some other convenience make targets
so you can quickly compile a version locked requirements.txt by
running `make pip-compile` and quickly install dependencies by
running `make pip-install`