### PR TITLE
Simplify command registration

### DIFF
--- a/gemini/__main__.py
+++ b/gemini/__main__.py
@@ -8,20 +8,20 @@ def cli():
     pass
 
 
-@click.command()
+@cli.command()
 def version() -> None:
     """Returns version information"""
     click.echo("v0.0.1")
 
 
-@click.command()
+@cli.command()
 def master() -> None:
     """Runs the master daemon"""
     click.echo("Hello from master")
     start_master()
 
 
-@click.command()
+@cli.command()
 def node() -> None:
     """Runs the node daemon"""
     click.echo("Hello from node")
@@ -29,7 +29,4 @@ def node() -> None:
 
 
 if __name__ == "__main__":
-    cli.add_command(version)
-    cli.add_command(master)
-    cli.add_command(node)
     cli()


### PR DESCRIPTION
It's easier to use the group decorator than to manually add every command to the group.